### PR TITLE
Dockerfile, rm double formasaurus requirement

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+*
+!requirements.txt
+!README.rst
+!deep-deep/deepdeep
+!deep-deep/setup.py
+!deep-deep/scrapy.cfg
+**/__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.5
+
+WORKDIR /opt/deep-deep
+
+RUN apt-get update && apt-get install -y tree
+
+COPY requirements.txt .
+RUN pip install -U pip wheel && \
+    pip install -r requirements.txt
+
+COPY deep-deep .
+RUN tree
+RUN pip install -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ scrapy==1.1.1
 networkx==1.11
 scikit-learn==0.17.1
 joblib
-formasaurus
 psutil
 numpy
 formasaurus[with_deps]


### PR DESCRIPTION
No entrypoint or command is listed, because there are too many options. Probably the most versatile is the relevancy crawl, maybe it makes sense to add it as an entrypoint?
