### PR TITLE
Memory improvements

### DIFF
--- a/deep-deep/deepdeep/qlearning.py
+++ b/deep-deep/deepdeep/qlearning.py
@@ -81,7 +81,7 @@ from scipy import sparse
 import sklearn.base
 from sklearn.linear_model import SGDRegressor
 
-from deepdeep.utils import log_time
+from deepdeep.utils import log_time, csr_nbytes
 
 
 class QLearner:
@@ -153,6 +153,9 @@ class QLearner:
     er_maxsize: int, optional
         Max size of experience replay memory. None (default) means there
         is no limit.
+    er_maxlinks: int, optional
+        Max number of links in experience replay memory.
+        None (default) means there is no limit.
     """
     def __init__(self, *,
                  double_learning: bool = True,
@@ -164,7 +167,8 @@ class QLearner:
                  on_model_changed: Optional[Callable[[], None]]=None,
                  pickle_memory: bool = True,
                  dummy: bool = False,
-                 er_maxsize: Optional[int] = None
+                 er_maxsize: Optional[int] = None,
+                 er_maxlinks: Optional[int] = None
                  ) -> None:
         assert 0 <= gamma < 1
         self.double_learning = double_learning
@@ -188,7 +192,7 @@ class QLearner:
         )
 
         self.clf_target = sklearn.base.clone(self.clf_online)  # type: SGDRegressor
-        self.memory = ExperienceMemory(maxsize=er_maxsize)
+        self.memory = ExperienceMemory(maxsize=er_maxsize, maxlinks=er_maxlinks)
         self.t_ = 0
 
     @classmethod
@@ -361,7 +365,10 @@ class QLearner:
 
     def __getstate__(self):
         dct = self.__dict__.copy()
-        del dct['on_model_changed']
+        try:
+            del dct['on_model_changed']
+        except KeyError:
+            pass
         if not self.pickle_memory:
             dct['memory'] = ExperienceMemory()
         return dct
@@ -385,10 +392,21 @@ class ExperienceMemory:
 
         Ring buffer would have been more aggressive pruning old observations;
         average age would have been ``maxsize/2`` with a ring buffer.
+
+    maxlinks : int, optional
+        Has the same logic as maxsize, but controls maximum number of links:
+        each observation can contain multiple links. This is useful to
+        control in case of running separate spiders for each domain,
+        as different domains have different average number of links.
     """
-    def __init__(self, maxsize: Optional[int]=None) -> None:
+    def __init__(self,
+                 maxsize: Optional[int]=None,
+                 maxlinks: Optional[int]=None,
+                 ) -> None:
         self.data = []  # type: List[Tuple[Any, Any, Any]]
         self.maxsize = maxsize
+        self.maxlinks = maxlinks
+        self._n_links = 0
 
     def add(self, as_t, AS_t1, r_t1) -> None:
         """
@@ -400,10 +418,19 @@ class ExperienceMemory:
         # TODO: In AS matrix rows of S columns usually contains the same data;
         # delta-compress them?
         item = (as_t, AS_t1, r_t1)
-        if self.maxsize is None or len(self.data) < self.maxsize:
+        too_large = False
+        if self.maxsize and len(self.data) >= self.maxsize:
+            too_large = True
+        elif self.maxlinks and self._n_links >= self.maxlinks:
+            too_large = True
+        self._n_links += AS_t1.shape[0] if AS_t1 is not None else 0
+        if not too_large:
             self.data.append(item)
         else:
             idx = random.randint(0, len(self.data)-1)
+            removed = self.data[idx]
+            if removed[1] is not None:
+                self._n_links -= removed[1].shape[0]
             self.data[idx] = item
 
     def sample(self, k: int) -> List[Tuple[Any, Any, Any]]:
@@ -416,6 +443,14 @@ class ExperienceMemory:
 
     def clear(self) -> None:
         self.data.clear()
+        self._n_links = 0
 
     def __len__(self) -> int:
         return len(self.data)
+
+    def nbytes(self) -> int:
+        """
+        Memory taken by sparse matrices in self.data.
+        """
+        return sum(csr_nbytes(as_t) + csr_nbytes(AS_t1)
+                   for as_t, AS_t1, _ in self.data)

--- a/deep-deep/deepdeep/queues.py
+++ b/deep-deep/deepdeep/queues.py
@@ -28,7 +28,7 @@ from typing import (
 
 import numpy as np
 import scrapy
-from deepdeep.utils import softmax, log_time
+from deepdeep.utils import softmax, log_time, csr_nbytes
 
 
 FLOAT_PRIORITY_MULTIPLIER = 10000
@@ -51,7 +51,7 @@ class RequestsPriorityQueue(Sized):
     In-memory priority queue for requests.
 
     Unlike default Scrapy queues it supports high-cardinality priorities
-    (but no float priorities becase scrapy.Request doesn't support them).
+    (but no float priorities because scrapy.Request doesn't support them).
 
     This queue allows to change request priorities. To do it
 
@@ -59,7 +59,9 @@ class RequestsPriorityQueue(Sized):
     2. call queue.change_priority(entry, new_priority) for each entry;
     3. call queue.heapify()
 
-    It also allows to remove a request from a queue using remove_entry.
+    It also allows to remove a request from a queue using remove_entry,
+    and limit queue size with maxsize argument (queue is trimmed when
+    updating request priorities).
     """
 
     REMOVED = object()
@@ -67,11 +69,12 @@ class RequestsPriorityQueue(Sized):
     REMOVED_PRIORITY = score_to_priority(15000)
     EMPTY_PRIORITY = score_to_priority(-15000)
 
-    def __init__(self, fifo: bool=True) -> None:
+    def __init__(self, fifo: bool=True, maxsize: Optional[int]=None) -> None:
         # entries are lists of [int, int, scrapy.Request]
         self.entries = []  # type: List[List]
         step = 1 if fifo else -1
         self.counter = itertools.count(step=step)
+        self.maxsize = maxsize
 
     def push(self, request: scrapy.Request) -> List:
         count = next(self.counter)
@@ -120,8 +123,21 @@ class RequestsPriorityQueue(Sized):
         """
         requests = list(self.iter_requests())
         new_priorities = compute_priority_func(requests)
-        for entry, priority in zip(self.iter_active_entries(), new_priorities):
-            self.change_priority(entry, priority)
+        n = len(new_priorities)
+        if self.maxsize and n > self.maxsize:
+            n_rm = n - self.maxsize
+            to_remove_idx = np.array(new_priorities).argpartition(n_rm)[:n_rm]
+            to_remove = np.zeros(n, dtype=np.bool)
+            to_remove[to_remove_idx] = True
+        else:
+            to_remove = itertools.repeat(False)
+        for entry, priority, remove in zip(self.iter_active_entries(),
+                                           new_priorities,
+                                           to_remove):
+            if remove:
+                self.remove_entry(entry)
+            else:
+                self.change_priority(entry, priority)
         self.heapify()
 
     def remove_entry(self, entry: List) -> scrapy.Request:
@@ -182,6 +198,12 @@ class RequestsPriorityQueue(Sized):
 
     def __len__(self) -> int:
         return len(self.entries)
+
+    def nbytes(self) -> int:
+        """
+        Memory taken by link vectors in requests stored in self.entries.
+        """
+        return sum(request_nbytes(request) for _, _, request in self.entries)
 
 
 class BalancedPriorityQueue:
@@ -338,3 +360,18 @@ class BalancedPriorityQueue:
 
     def __len__(self) -> int:
         return sum(len(q) for q in self.queues.values()) + len(self._buffer)
+
+    def nbytes(self) -> int:
+        """
+        Memory taken by link vectors in requests stored in all queues
+        and self.buffer.
+        """
+        return (sum(q.nbytes() for q in self.queues.values()) +
+                sum(map(request_nbytes, self._buffer)))
+
+
+def request_nbytes(request):
+    if hasattr(request, 'meta'):
+        return csr_nbytes(request.meta.get('link_vector'))
+    else:
+        return 0

--- a/deep-deep/deepdeep/spiders/_base.py
+++ b/deep-deep/deepdeep/spiders/_base.py
@@ -90,7 +90,7 @@ class BaseSpider(scrapy.Spider):
         self.response_count += 1
         max_items = self.crawler.settings.getint('CLOSESPIDER_ITEMCOUNT',
                                                  float('inf'))
-        if self.response_count >= max_items:
+        if max_items != 0 and self.response_count >= max_items:
             raise CloseSpider("item_count")
 
     def on_offdomain_request_dropped(self, request):

--- a/deep-deep/deepdeep/utils.py
+++ b/deep-deep/deepdeep/utils.py
@@ -12,6 +12,7 @@ import zlib
 import numpy as np
 import parsel
 import lxml.html
+from scipy.sparse.csr import csr_matrix
 import tldextract
 from lxml import etree  # type: ignore
 from lxml.html.clean import Cleaner  # type: ignore
@@ -234,3 +235,15 @@ def iter_jsonlines(path):
         except (EOFError, zlib.error):
             logging.warning("Error found: tuncated archive.")
             return
+
+
+def csr_nbytes(m: csr_matrix) -> int:
+    if m is not None:
+        return m.data.nbytes + m.indices.nbytes + m.indptr.nbytes
+    else:
+        return 0
+
+
+def chunks(lst, chunk_size: int):
+    for idx in range(0, len(lst), chunk_size):
+        yield lst[idx: idx + chunk_size]


### PR DESCRIPTION
A number of memory improvements and settings to control
memory usage. The aim is to make it more practical
to run deep-deep crawls (especially for one website),
and to make memory usage more predictable.

New options:

* An option to checkpoint only latest Q and queue to save disk space.
* An option to limit domain queue size. Entries with lowest priorities
  are removed from the queue during priority update step.
* An option to limit number of links in replay.
  Some sites can have lots of links per page.

Memory optimizations:

* Do prediction in chunks to save memory. Creating a huge matrix of
  all links in the queue trashes a lot of memory,
  the queue can be quite big.
* Save a bit of memory by storing values as float32 instead of float64.
  float16 is also an option, but we still have to store indices,
  so it gives less improvement and might be more brittle.

Logging and misc.:

* Log memory used by queue and replay vectors
* Less frequent logging for tensorboard
* Fix reporting in case queue is empty
* Do not close spider with 0 max item count