### PR TITLE
Extraction spider, more options

### DIFF
--- a/deep-deep/deepdeep/links.py
+++ b/deep-deep/deepdeep/links.py
@@ -111,6 +111,7 @@ def extract_link_dicts(
 
 def iter_response_link_dicts(response: TextResponse,
                              limit_by_domain: bool=True) -> Iterator[Dict]:
+    page_url = response.url
     domain_from = get_domain(response.url)
     base_url = get_base_url(response)
     for link in extract_link_dicts(response.selector, base_url):
@@ -118,6 +119,7 @@ def iter_response_link_dicts(response: TextResponse,
         if limit_by_domain and link['domain_to'] != domain_from:
             continue
         link['domain_from'] = domain_from
+        link['page_url'] = page_url
         yield link
 
 

--- a/deep-deep/deepdeep/qlearning.py
+++ b/deep-deep/deepdeep/qlearning.py
@@ -168,7 +168,9 @@ class QLearner:
                  pickle_memory: bool = True,
                  dummy: bool = False,
                  er_maxsize: Optional[int] = None,
-                 er_maxlinks: Optional[int] = None
+                 er_maxlinks: Optional[int] = None,
+                 clf_penalty: str='l2',
+                 clf_alpha: float=1e-6
                  ) -> None:
         assert 0 <= gamma < 1
         self.double_learning = double_learning
@@ -182,12 +184,12 @@ class QLearner:
         self.dummy = dummy
 
         self.clf_online = SGDRegressor(
-            penalty='l2',
+            penalty=clf_penalty,
             average=False,
             n_iter=1,
             learning_rate='constant',
             # loss='epsilon_insensitive',
-            alpha=1e-6,
+            alpha=clf_alpha,
             eta0=0.1,
         )
 

--- a/deep-deep/deepdeep/spiders/_base.py
+++ b/deep-deep/deepdeep/spiders/_base.py
@@ -75,6 +75,9 @@ class BaseSpider(scrapy.Spider):
 
     def _parse_seeds(self, response):
         urls = list(self._get_urls(io.StringIO(response.text)))
+        yield from self._start_requests(urls)
+
+    def _start_requests(self, urls):
         random.shuffle(urls)
         for url in urls:
             yield scrapy.Request(url, self.parse, priority=self.initial_priority)

--- a/deep-deep/deepdeep/spiders/extraction.py
+++ b/deep-deep/deepdeep/spiders/extraction.py
@@ -1,0 +1,237 @@
+import importlib
+import traceback
+from typing import Any, Callable, Iterable, Tuple
+from weakref import WeakKeyDictionary
+
+import autopager
+from scrapy import Request
+from scrapy.dupefilters import RFPDupeFilter
+from scrapy.http.response.text import TextResponse
+
+from .qspider import QSpider
+from deepdeep.goals import BaseGoal
+
+
+class ExtractionGoal(BaseGoal):
+    def __init__(self,
+                 extractor: Callable[[TextResponse], Iterable[Tuple[Any, Any]]],
+                 request_penalty: float=1.0,
+                 item_callback=None,
+                 ) -> None:
+        """ The goal is to find the maximum number of unique items by doing
+        minimum number of requests.
+
+        Parameters
+        ----------
+        extractor : callable
+            A function that extracts key-item pairs for each item found in
+            response. Key is a unique item identifier
+            (like item_id or item_type and item_id), and item is extracted
+            data.
+        request_penalty : float
+            Penalty for making a request (default: 1.0).
+            Reward is calculated as number of items minus request penalty.
+        item_callback : callable
+            A function that will be called with response.url, key, item
+            for each extracted item.
+        """
+        self.extractor = extractor
+        self.extracted_items = set()
+        self.request_reward = -request_penalty
+        self.item_reward = 1.0
+        self.item_callback = item_callback
+        self._cache = WeakKeyDictionary()  # type: WeakKeyDictionary
+
+    def get_reward(self, response: TextResponse) -> float:
+        if response not in self._cache:
+            score = self.request_reward
+            run_id = response.meta['run_id']
+            try:
+                items = list(self.extractor(response))
+            except Exception:
+                traceback.print_exc()
+            else:
+                for key, item in items:
+                    full_key = (run_id, key)
+                    if full_key not in self.extracted_items:
+                        self.extracted_items.add(full_key)
+                        score += self.item_reward
+                    if self.item_callback:
+                        self.item_callback(response.url, key, item)
+            self._cache[response] = score
+        return self._cache[response]
+
+    def response_observed(self, response: TextResponse):
+        pass
+
+
+class ExtractionSpider(QSpider):
+    """
+    This spider learns how to extract data from a single domain.
+    It uses ExtractionGoal goal (extracting maximum number of unique items using
+    minimal number of requests).
+
+    Spider arguments
+    ----------------
+    extractor : str
+        This required argument specifies the python path to the extractor
+        function, and has the form "python.module:function". This function is
+        passed as ``extractor`` argument to ``ExtractionGoal``.
+    export_items : bool
+        Set this option to get extracted items in spider output. The format
+        Each unique item returned by the extractor function will produce an item
+        with 3 fields: 'url' is the response url,
+        'key' is the key returned by the extractor function, and item is item
+        returned by the extractor function.
+    seed_url : str
+        Set this argument in order to start crawling from a single seed URL
+        specified from the command line (if you need multiple seeds,
+        specify a path to a file with them via seeds_url).
+    n_copies : int
+        Number of spider "copies" run at the same time (1 by default).
+        This copies have independed request queues and cookies, but share
+        the same model. This option makes sense when your goal is to train
+        a model tha will later be used elsewhere: running several copies reduces
+        the chance that the model will learn features that change from run
+        to run (e.g. session ids in URLs or depending on a particular order of
+        traversal), so the model should be more general.
+
+    It also accepts all arguments accepted by QSpider and BaseSpider.
+
+    Many arguments have different default values because this spider
+    crawls a single domain instead of multiple domains assumed for QSpider,
+    and to make memory consumption more predictable to make it more practical
+    to run this spider for item extraction (as opposed to model training).
+    Current default configuration will require about 3-6 GB of memory
+    for a typical large website.
+    """
+    name = 'extraction'
+    use_urls = True
+    use_link_text = 1
+    use_page_urls = 1
+    use_same_domain = 0  # not supported by eli5 yet, and we don't need it
+    clf_penalty = 'l1'
+    clf_alpha = 0.0001
+    balancing_temperature = 5.0  # high to make all simultaneous runs equal
+    export_items = 1
+    export_cdr = 0
+    seed_url = None
+    replay_sample_size = 50
+    replay_maxsize = 5000  # single site needs lower replay
+    replay_maxlinks = 500000  # some sites can have lots of links per page
+    domain_queue_maxsize = 500000
+    # number of simultaneous runs
+    n_copies = 1
+
+    _ARGS = {'extractor', 'n_copies', 'seed_url', 'export_items'} | QSpider._ARGS
+    ALLOWED_ARGUMENTS = _ARGS | QSpider.ALLOWED_ARGUMENTS
+
+    custom_settings = dict(
+        DUPEFILTER_CLASS='deepdeep.spiders.extraction.RunAwareDupeFilter',
+        **QSpider.custom_settings)
+
+    def __init__(self, *args, **kwargs):
+        """ extractor argument has a "module:function" format
+        and specifies where to load the extractor from.
+        """
+        super().__init__(*args, **kwargs)
+        self.n_copies = int(self.n_copies)
+        self.extractor = str(self.extractor)
+        self.seed_url = self.seed_url
+        self.export_items = bool(int(self.export_items))
+        self.exported_keys = set()
+        self.export_buffer = []
+
+    def get_goal(self):
+        try:
+            ex_module, ex_function = self.extractor.split(':')
+        except (AttributeError, ValueError):
+            raise ValueError(
+                'Please give extractor argument in "module:function" format')
+        ex_module = importlib.import_module(ex_module)
+        extractor_fn = getattr(ex_module, ex_function)
+        return ExtractionGoal(extractor_fn, item_callback=self.item_callback)
+
+    def item_callback(self, url, key, item):
+        if self.export_items and key not in self.exported_keys:
+            self.export_buffer.append({'url': url, 'key': key, 'item': item})
+            self.exported_keys.add(key)
+
+    def parse(self, response):
+        parse_result = super().parse(response)
+        self.log_value('Reward/total-items', len(self.exported_keys))
+        if self.export_items:
+            yield from self.export_buffer
+            self.export_buffer = []
+            for item_or_link in parse_result:
+                if isinstance(item_or_link, Request):
+                    yield item_or_link
+        else:
+            yield from parse_result
+
+    def start_requests(self):
+        if self.seeds_url is None:
+            if self.seed_url is None:
+                raise ValueError('Pass seeds_url or seed_url')
+            yield from self._start_requests([self.seed_url])
+        else:
+            yield from super().start_requests()
+
+    # Allow running several simultaneous independent spiders on the same domain
+    # which still share the model, so it is more general.
+
+    def _start_requests(self, urls):
+        for orig_req in super()._start_requests(urls):
+            for idx in range(self.n_copies):
+                req = orig_req.copy()
+                set_run_id(req, 'run-{}'.format(idx))
+                yield req
+
+    def _links_to_requests(self, response, *args, **kwargs):
+        run_id = response.request.meta['run_id']
+        for req in super()._links_to_requests(response, *args, **kwargs):
+            set_run_id(req, run_id)
+            yield req
+
+
+class AutopagerBaseline(ExtractionSpider):
+    """ A BFS + autopager baseline. This spider crawles in breadth-first order,
+    but does not increase depth for pagination links. Used only as a baseline
+    to compare ExtractionSpider against.
+    """
+    name = 'autopager_extraction'
+    baseline = True
+    eps = 0.0  # do not select requests at random
+    # disable depth middleware to avoid increasing depth for pagination urls
+    custom_settings = dict(ExtractionSpider.custom_settings)
+    custom_settings['SPIDER_MIDDLEWARES'] = dict(
+        custom_settings.get('SPIDER_MIDDLEWARES', {}))
+    custom_settings['SPIDER_MIDDLEWARES'][
+        'scrapy.spidermiddlewares.depth.DepthMiddleware'] = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.autopager = autopager.AutoPager()
+
+    def _links_to_requests(self, response, *args, **kwargs):
+        pagination_urls = set(self.autopager.urls(response))
+        depth = response.meta.get('depth', 1)
+        real_depth = response.meta.get('real_depth', 1)
+        for req in super()._links_to_requests(response, *args, **kwargs):
+            is_pagination = req.url in pagination_urls
+            req.meta['depth'] = depth + (1 - is_pagination)
+            req.meta['real_depth'] = real_depth + 1
+            req.meta['is_pagination'] = is_pagination
+            req.priority = -100 * req.meta['depth']
+            yield req
+
+
+def set_run_id(request: Request, run_id: str):
+    for key in ['run_id', 'cookiejar', 'scheduler_slot']:
+        request.meta[key] = run_id
+
+
+class RunAwareDupeFilter(RFPDupeFilter):
+    def request_fingerprint(self, request):
+        fp = super().request_fingerprint(request)
+        return '{}-{}'.format(request.meta.get('run_id'), fp)

--- a/deep-deep/deepdeep/spiders/relevancy.py
+++ b/deep-deep/deepdeep/spiders/relevancy.py
@@ -118,13 +118,14 @@ class ClassifierRelevancySpider(_RelevancySpider):
         'classifier_path',
         'classifier_input',
     }
-    CLASSIFIER_INPUT_ALLOWED_VALUES = ['text', 'html', 'vector']
+    CLASSIFIER_INPUT_ALLOWED_VALUES = ['text', 'text_url', 'html', 'vector']
 
     # a file with saved page relevancy classifier
     classifier_path = None  # type: str
 
     # Relevancy classifier input. Allowed values:
     # * 'text' - use text content of the response (default);
+    # * 'text_url' - use text content and url of the response;
     # * 'html' - use raw HTML of the response;
     # * 'vector' - reuse page vector computed for Q learning.
     classifier_input = 'text'
@@ -152,9 +153,11 @@ class ClassifierRelevancySpider(_RelevancySpider):
             x = self._page_vector(response)
         elif self.classifier_input == 'text':
             x = html2text(response.text)
+        elif self.classifier_input == 'text_url':
+            x = {'text': html2text(response.text), 'url': response.url}
         elif self.classifier_input == 'html':
             x = response.text
         else:
             raise ValueError("self.classifier_input is invalid")
 
-        return self.relevancy_clf.predict_proba([x])[0, 1]
+        return float(self.relevancy_clf.predict_proba([x])[0, 1])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-scrapy==1.1.1
+scrapy==1.3.2
 networkx==1.11
-scikit-learn==0.17.1
+scikit-learn==0.18.1
 joblib
 psutil
 numpy
@@ -9,4 +9,5 @@ scrapy-cdr
 tldextract
 stop-words
 docopt
-tensorboard_logger>=0.0.2
+tensorboard_logger>=0.0.3
+autopager>=0.2


### PR DESCRIPTION
- Add an extraction spiders that crawl a single domain with the goal of
  extracting maximal number of items making minimal number of requests.
  Extractors are user-provided. They are described in more details the
  docstring.
- Expose more feature options: use_link_text (was always on, but in case
  of single domain crawls link URLs can be enough), use_page_urls,
  use_full_page_urls - these two are new, they allow using current page
  url as a feature (this makes sense for single domain crawls and improves
  efficiency in items/requests by 5-20 %).
- Expose classifier regularisation parameters as options (clf_alpha,
  clf_penalty).
- Log running average of reward.
- Update scrapy and scikit-learn versions.