### PR TITLE
use json-lines and html-text packages

### DIFF
--- a/deep-deep/deepdeep/score_pages.py
+++ b/deep-deep/deepdeep/score_pages.py
@@ -5,8 +5,9 @@ from typing import List
 import formasaurus  # type: ignore
 from formasaurus.text import tokenize, token_ngrams  # type: ignore
 from scrapy.http import Response  # type: ignore
+import html_text  # type: ignore
 
-from deepdeep.utils import dict_aggregate_max, html2text
+from deepdeep.utils import dict_aggregate_max
 
 
 # ========== form-based relevancy functions
@@ -68,7 +69,7 @@ def keyword_relevancy(response_html: str,
                       pos_keywords: List[str],
                       neg_keywords: List[str],
                       max_ngram=1):
-    text = html2text(response_html).lower()
+    text = html_text.extract_text(response_html).lower()
     return keyword_text_relevancy(text, pos_keywords, neg_keywords, max_ngram)
 
 

--- a/deep-deep/deepdeep/spiders/relevancy.py
+++ b/deep-deep/deepdeep/spiders/relevancy.py
@@ -7,10 +7,10 @@ from typing import Any, Dict, List, Optional
 
 import joblib  # type: ignore
 from scrapy.http import Response, TextResponse  # type: ignore
+import html_text  # type: ignore
 
 from .qspider import QSpider
 from deepdeep.goals import RelevancyGoal
-from deepdeep.utils import html2text
 
 
 class _RelevancySpider(QSpider, metaclass=abc.ABCMeta):
@@ -152,9 +152,12 @@ class ClassifierRelevancySpider(_RelevancySpider):
         if self.classifier_input == 'vector':
             x = self._page_vector(response)
         elif self.classifier_input == 'text':
-            x = html2text(response.text)
+            x = html_text.extract_text(response.text)
         elif self.classifier_input == 'text_url':
-            x = {'text': html2text(response.text), 'url': response.url}
+            x = {
+                'text': html_text.extract_text(response.text),
+                'url': response.url
+            }
         elif self.classifier_input == 'html':
             x = response.text
         else:

--- a/deep-deep/deepdeep/utils.py
+++ b/deep-deep/deepdeep/utils.py
@@ -208,37 +208,6 @@ def canonicalize_url(url: str) -> str:
     return _canonicalize_url(url)
 
 
-def maybe_gzip_open(path, *args, **kwargs):
-    """
-    Open file with either open or gzip.open, depending on file extension.
-    """
-    if path.endswith(".gz"):
-        _open = gzip.open
-    else:
-        _open = open
-    return _open(path, *args, **kwargs)
-
-
-def iter_jsonlines(path):
-    """
-    Read .jl or .jl.gz file with JSON lines data,
-    return iterator with decoded lines.
-    If the .jl.gz archive is broken as much lines as possible are read from
-    the archive, and then an error is logged.
-    """
-    with maybe_gzip_open(str(path), 'rt', encoding='utf8') as f_in:
-        try:
-            for line in f_in:
-                try:
-                    yield json.loads(line)
-                except Exception as e:
-                    logging.warning("Error found: JSON line can't be decoded. %r" % e)
-                    break
-        except (EOFError, zlib.error):
-            logging.warning("Error found: tuncated archive.")
-            return
-
-
 def csr_nbytes(m: csr_matrix) -> int:
     if m is not None:
         return m.data.nbytes + m.indices.nbytes + m.indptr.nbytes

--- a/deep-deep/deepdeep/vectorizers.py
+++ b/deep-deep/deepdeep/vectorizers.py
@@ -9,8 +9,9 @@ from sklearn.feature_extraction.text import HashingVectorizer, CountVectorizer  
 from sklearn.pipeline import make_union, make_pipeline  # type: ignore
 from sklearn.preprocessing import FunctionTransformer, Normalizer  # type: ignore
 from formasaurus.text import normalize  # type: ignore
+import html_text  # type: ignore
 
-from deepdeep.utils import url_path_query, html2text, canonicalize_url
+from deepdeep.utils import url_path_query, canonicalize_url
 
 
 def LinkVectorizer(use_url: bool=False,
@@ -145,4 +146,4 @@ def _same_domain_feature(links):
 
 
 def _html_text_lower(html: str) -> str:
-    return html2text(html).lower()
+    return html_text.extract_text(html).lower()

--- a/deep-deep/scripts/show-lda-topics.py
+++ b/deep-deep/scripts/show-lda-topics.py
@@ -18,12 +18,13 @@ import joblib
 from docopt import docopt
 from tqdm import tqdm
 from sklearn.pipeline import Pipeline
-
-from deepdeep.utils import iter_jsonlines
+import json_lines
 
 
 def iter_html(path):
-    return (line['raw_content'] for line in iter_jsonlines(path))
+    with json_lines.open(path, broken=True) as lines:
+        for line in lines:
+            yield line['raw_content']
 
 
 def print_top_words(model, feature_names, n_top_words, word_threshold=0.11):

--- a/deep-deep/scripts/train-lda.py
+++ b/deep-deep/scripts/train-lda.py
@@ -17,13 +17,15 @@ sys.path.insert(0, str((Path(__file__).parent / "..").absolute()))
 from docopt import docopt
 import joblib
 from tqdm import tqdm
+import json_lines
 
 from deepdeep.vectorizers import LDAPageVctorizer
-from deepdeep.utils import iter_jsonlines
 
 
 def iter_html(path):
-    return (line['raw_content'] for line in iter_jsonlines(path))
+    with json_lines.open(path, broken=True) as lines:
+        for line in lines:
+            yield line['raw_content']
 
 
 def train(cdr_jlgz, n_topics=50, batch_size=1024, min_df=4, max_features=None):

--- a/deep-deep/setup.py
+++ b/deep-deep/setup.py
@@ -33,6 +33,7 @@ setup(
         'numpy',
         'scrapy-cdr',
         'json-lines >= 0.3.1',
+        'html-text >= 0.1.1',
         'formasaurus[with_deps]',  # fixme: remove it
     ],
 )

--- a/deep-deep/setup.py
+++ b/deep-deep/setup.py
@@ -32,6 +32,7 @@ setup(
         'joblib',
         'numpy',
         'scrapy-cdr',
+        'json-lines >= 0.3.1',
         'formasaurus[with_deps]',  # fixme: remove it
     ],
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ docopt
 tensorboard_logger>=0.0.3
 autopager>=0.2
 eli5>=0.6
+json-lines>=0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ docopt
 tensorboard_logger>=0.0.3
 autopager>=0.2
 eli5>=0.6
-json-lines>=0.3.1
+json-lines==0.3.1
+html-text==0.1.1


### PR DESCRIPTION
As I recall, we extracted them mainly from deep-deep, but haven't switched deep-deep itself to use these dependencies.

This change may require updates to some of the internal projects which import from deep-deep.