### PR TITLE
Onion proxy support

### DIFF
--- a/deep-deep/deepdeep/downloadermiddlewares.py
+++ b/deep-deep/deepdeep/downloadermiddlewares.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from scrapy.exceptions import IgnoreRequest  # type: ignore
+from scrapy.exceptions import NotConfigured, IgnoreRequest  # type: ignore
 
 from deepdeep.utils import get_domain
 
@@ -33,4 +33,6 @@ class OffsiteDownloaderMiddleware:
 
     @classmethod
     def from_crawler(cls, crawler):
+        if not crawler.settings.getbool('OFFSITE_ENABLED'):
+            raise NotConfigured
         return cls(crawler.signals)

--- a/deep-deep/deepdeep/settings.py
+++ b/deep-deep/deepdeep/settings.py
@@ -93,6 +93,9 @@ DOWNLOADER_MIDDLEWARES = {
    'deepdeep.downloadermiddlewares.OffsiteDownloaderMiddleware': 543,
 }
 
+# Enable 'deepdeep.downloadermiddlewares.OffsiteDownloaderMiddleware'
+OFFSITE_ENABLED = True
+
 # Enable or disable extensions
 # See http://scrapy.readthedocs.org/en/latest/topics/extensions.html
 EXTENSIONS = {

--- a/deep-deep/deepdeep/settings.py
+++ b/deep-deep/deepdeep/settings.py
@@ -89,6 +89,7 @@ CRAWLGRAPH_ENABLED = False
 # Enable or disable downloader middlewares
 # See http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 DOWNLOADER_MIDDLEWARES = {
+   'proxy_middleware.ProxyOnlyTorMiddleware': 10,
    'deepdeep.downloadermiddlewares.OffsiteDownloaderMiddleware': 543,
 }
 

--- a/deep-deep/deepdeep/spiders/qspider.py
+++ b/deep-deep/deepdeep/spiders/qspider.py
@@ -137,7 +137,7 @@ class QSpider(BaseSpider, metaclass=abc.ABCMeta):
 
     # Is spider allowed to follow out-of-domain links?
     # XXX: it is not enough to set this to False; a middleware should be also
-    # turned off.
+    # turned off via OFFSITE_ENABLED = False.
     stay_in_domain = True
 
     # use baseline algorithm (BFS) instead of Q-Learning

--- a/deep-deep/deepdeep/spiders/relevancy.py
+++ b/deep-deep/deepdeep/spiders/relevancy.py
@@ -39,16 +39,10 @@ class _RelevancySpider(QSpider, metaclass=abc.ABCMeta):
     max_requests_per_domain = None  # type: Optional[int]
     max_relevant_pages_per_domain = None  # type: Optional[int]
 
-    custom_settings = {
-        # copied from QSpider
-        # 'DEPTH_LIMIT': 100,
-        'DEPTH_PRIORITY': 1,
-
-        # disable OffsiteDownloaderMiddleware
-        'DOWNLOADER_MIDDLEWARES': {
-           'deepdeep.downloadermiddlewares.OffsiteDownloaderMiddleware': None,
-        },
-    }  # type: Dict[str, Any]
+    custom_settings = dict(
+        QSpider.custom_settings,
+        OFFSITE_ENABLED=False,
+    )
 
     @abc.abstractmethod
     def relevancy(self, response: Response) -> float:

--- a/deep-deep/setup.py
+++ b/deep-deep/setup.py
@@ -34,6 +34,7 @@ setup(
         'scrapy-cdr',
         'json-lines >= 0.3.1',
         'html-text >= 0.1.1',
+        'proxy-middleware >= 0.2.0',
         'formasaurus[with_deps]',  # fixme: remove it
     ],
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ autopager>=0.2
 eli5>=0.6
 json-lines==0.3.1
 html-text==0.1.1
+proxy-middleware==0.2.0


### PR DESCRIPTION
This adds ``ProxyOnlyTorMiddleware`` (https://github.com/TeamHG-Memex/proxy-middleware#proxyonlytormiddleware) that allows to proxy requests to onion sites if ``HTTP(S)_PROXY`` is set.

Also I changed the way ``OffsiteDownloaderMiddleware`` is configured, because it's less convenient to turn it off by changing ``DOWNLOADER_MIDDLEWARES`` in spider custom_settings. I needed it because I added a new middleware and without this it was disabled in relevancy spider.