### PR TITLE
Refactoring: simplify goal definition

### DIFF
--- a/deep-deep/deepdeep/spiders/extraction.py
+++ b/deep-deep/deepdeep/spiders/extraction.py
@@ -40,29 +40,23 @@ class ExtractionGoal(BaseGoal):
         self.request_reward = -request_penalty
         self.item_reward = 1.0
         self.item_callback = item_callback
-        self._cache = WeakKeyDictionary()  # type: WeakKeyDictionary
 
     def get_reward(self, response: TextResponse) -> float:
-        if response not in self._cache:
-            score = self.request_reward
-            run_id = response.meta['run_id']
-            try:
-                items = list(self.extractor(response))
-            except Exception:
-                traceback.print_exc()
-            else:
-                for key, item in items:
-                    full_key = (run_id, key)
-                    if full_key not in self.extracted_items:
-                        self.extracted_items.add(full_key)
-                        score += self.item_reward
-                    if self.item_callback:
-                        self.item_callback(response.url, key, item)
-            self._cache[response] = score
-        return self._cache[response]
-
-    def response_observed(self, response: TextResponse):
-        pass
+        score = self.request_reward
+        run_id = response.meta['run_id']
+        try:
+            items = list(self.extractor(response))
+        except Exception:
+            traceback.print_exc()
+        else:
+            for key, item in items:
+                full_key = (run_id, key)
+                if full_key not in self.extracted_items:
+                    self.extracted_items.add(full_key)
+                    score += self.item_reward
+                if self.item_callback:
+                    self.item_callback(response.url, key, item)
+        return score
 
 
 class ExtractionSpider(QSpider):

--- a/deep-deep/deepdeep/spiders/qspider.py
+++ b/deep-deep/deepdeep/spiders/qspider.py
@@ -315,7 +315,7 @@ class QSpider(BaseSpider, metaclass=abc.ABCMeta):
 
         reward = 0
         if not self.is_seed(response):
-            reward = self.goal.get_reward_cached(response)
+            reward = self.goal.get_reward(response)
             self.update_node(response, {'reward': reward})
             self.total_reward += reward
             self.rewards.append(reward)

--- a/deep-deep/deepdeep/spiders/qspider.py
+++ b/deep-deep/deepdeep/spiders/qspider.py
@@ -136,11 +136,6 @@ class QSpider(BaseSpider, metaclass=abc.ABCMeta):
     # Store only latest checkpoint to save disk space.
     checkpoint_latest = 0
 
-    # Is spider allowed to follow out-of-domain links?
-    # XXX: it is not enough to set this to False; a middleware should be also
-    # turned off via OFFSITE_ENABLED = False.
-    stay_in_domain = True
-
     # use baseline algorithm (BFS) instead of Q-Learning
     baseline = False
 
@@ -158,7 +153,6 @@ class QSpider(BaseSpider, metaclass=abc.ABCMeta):
         self.use_page_urls = bool(int(self.use_page_urls))
         self.use_full_page_urls = bool(int(self.use_full_page_urls))
         self.double = int(self.double)
-        self.stay_in_domain = bool(int(self.stay_in_domain))
         self.steps_before_switch = int(self.steps_before_switch)
         self.replay_sample_size = int(self.replay_sample_size)
         self.replay_maxsize = int(self.replay_maxsize)
@@ -336,7 +330,7 @@ class QSpider(BaseSpider, metaclass=abc.ABCMeta):
         """ Return a list of all unique links on a page """
         return list(self.le.iter_link_dicts(
             response=response,
-            limit_by_domain=self.stay_in_domain,
+            limit_by_domain=not self.settings.getbool('OFFSITE_ENABLED'),
             deduplicate=False,
             deduplicate_local=True,
         ))

--- a/deep-deep/deepdeep/spiders/qspider.py
+++ b/deep-deep/deepdeep/spiders/qspider.py
@@ -330,7 +330,7 @@ class QSpider(BaseSpider, metaclass=abc.ABCMeta):
         """ Return a list of all unique links on a page """
         return list(self.le.iter_link_dicts(
             response=response,
-            limit_by_domain=not self.settings.getbool('OFFSITE_ENABLED'),
+            limit_by_domain=self.settings.getbool('OFFSITE_ENABLED'),
             deduplicate=False,
             deduplicate_local=True,
         ))

--- a/deep-deep/deepdeep/spiders/relevancy.py
+++ b/deep-deep/deepdeep/spiders/relevancy.py
@@ -27,7 +27,6 @@ class _RelevancySpider(QSpider, metaclass=abc.ABCMeta):
     }
 
     # overrides for default option values used in QSpider
-    stay_in_domain = False
     balancing_temperature = 0.1
     replay_sample_size = 50
     replay_maxsize = 100000  # decrease it to ~10K if use_pages is 1

--- a/deep-deep/deepdeep/utils.py
+++ b/deep-deep/deepdeep/utils.py
@@ -32,23 +32,7 @@ def dict_aggregate_max(*dicts):
 
 
 def get_domain(url: str) -> str:
-    """
-    >>> get_domain("http://foo.com")
-    'foo.com'
-    >>> get_domain("http://bar.FOO.com/path")
-    'foo.com'
-    >>> get_domain("http://foo.onion")
-    'foo.onion'
-    >>> get_domain("http://bar.foo.onion")
-    'foo.onion'
-    """
-    e = tldextract.extract(url)
-    if not e.suffix and e.domain == 'onion':
-        subdomain = e.subdomain.rsplit('.', 1)[-1]
-        domain = '{}.{}'.format(subdomain, e.domain)
-    else:
-        domain = e.registered_domain
-    return domain.lower()
+    return tldextract.extract(url).registered_domain.lower()
 
 
 def get_response_domain(response):

--- a/deep-deep/deepdeep/utils.py
+++ b/deep-deep/deepdeep/utils.py
@@ -32,7 +32,23 @@ def dict_aggregate_max(*dicts):
 
 
 def get_domain(url: str) -> str:
-    return tldextract.extract(url).registered_domain.lower()
+    """
+    >>> get_domain("http://foo.com")
+    'foo.com'
+    >>> get_domain("http://bar.FOO.com/path")
+    'foo.com'
+    >>> get_domain("http://foo.onion")
+    'foo.onion'
+    >>> get_domain("http://bar.foo.onion")
+    'foo.onion'
+    """
+    e = tldextract.extract(url)
+    if not e.suffix and e.domain == 'onion':
+        subdomain = e.subdomain.rsplit('.', 1)[-1]
+        domain = '{}.{}'.format(subdomain, e.domain)
+    else:
+        domain = e.registered_domain
+    return domain.lower()
 
 
 def get_response_domain(response):


### PR DESCRIPTION
Instead of doing caching in the goal (``get_reward`` and ``response_observed``), caching is done in ``QSpider``, and goals have to implement only ``get_reward`` that will be called only once for each response. This seems easier as there are multiple goals but just one ``QSpider``.
Also redundant ``stay_in_domain`` argument is removed, as the same property is already set by ``OFFSITE_ENABLED`` setting.